### PR TITLE
adapters: Adds header check in the "requestProxy" function.

### DIFF
--- a/lib/adapters/default.js
+++ b/lib/adapters/default.js
@@ -23,7 +23,10 @@ function requestProxy({ logger, level, traceHeaderName } = {}) {
       try {
         const incomingMessage = argumentsList[0];
 
-        reqId = incomingMessage.headers[traceHeaderName] ? incomingMessage.headers[traceHeaderName] : uuidv4();
+        reqId =
+          incomingMessage.headers && incomingMessage.headers[traceHeaderName]
+            ? incomingMessage.headers[traceHeaderName]
+            : uuidv4();
 
         reqObj = mapOutReq(incomingMessage, reqId);
         if (!reqObj.protocol) {


### PR DESCRIPTION
Check if the headers object exists,
before checking for it's key.

In rare cases, the "incomingMessage" can contain no headers.
This have happend in some cases with the "superagent" requests.