### PR TITLE
appenders: add missing query char "?"

### DIFF
--- a/lib/appenders/format.js
+++ b/lib/appenders/format.js
@@ -11,8 +11,9 @@ const inReqH = logTags.CATEGORY.INBOUND_REQUEST_HEALTH;
 const outResH = logTags.CATEGORY.OUTBOUND_RESPONSE_HEALTH;
 const unexpectedErr = logTags.CATEGORY.UNEXPECTED_ERROR;
 
-getHrefFromRes = obj => {
-  return obj.href || obj.protocol + '://' + obj.host + (obj.path || '') + (obj.query || '');
+const getHrefFromRes = obj => {
+  const query = obj.query ? `?${obj.query}` : '';
+  return obj.href || `${obj.protocol}://${obj.host}${obj.path || ''}${query}`;
 };
 
 module.exports = (color = false, date = false) => {


### PR DESCRIPTION
The "inbound_response" message  was missing the query char "?"
when the query was defined.

Replace string concatenation "+" with template string "`".