### PR TITLE
Support async errbacks

### DIFF
--- a/index.js
+++ b/index.js
@@ -37,7 +37,7 @@ module.exports = {
         }
 
         if (typeof errors.callback === 'function') {
-          errors.callback(ctx, err);
+          await errors.callback(ctx, err);
         }
       } finally {
         if (inbound.enabled) {


### PR DESCRIPTION
Currently error callbacks (errbacks) support only synchronous code execution. However, in many apps we might need to invoke async functions inside the errback (e.g. when a view renderer is invoked). With this fix, async errbacks are supported in order to  be able to do the following:

```js
app.use(async(ctx, next) => {
  try {
    await next();
    if (ctx.status === 404) {
        ctx.throw(404);
    }
  } catch (err) {
    ctx.status = err.status || 500
    if (ctx.status === 404) {
      await ctx.render('404');
    } else {
      await ctx.render('other_error');
    }
  }
});
```