### PR TITLE
Makes the module export comply with what the typings.d.ts claim to export.

### DIFF
--- a/index.js
+++ b/index.js
@@ -46,6 +46,6 @@ function buildRiviere(options = {}) {
   };
 }
 
-buildRiviere;.riviere = buildRiviere;
+buildRiviere.riviere = buildRiviere;
 
 module.exports = buildRiviere;

--- a/index.js
+++ b/index.js
@@ -46,4 +46,6 @@ function buildRiviere(options = {}) {
   };
 }
 
+buildRiviere;.riviere = buildRiviere;
+
 module.exports = buildRiviere;


### PR DESCRIPTION
This is backwards compatible. Note that the `module.exports = function() {};` signature is practically unmockable. We should either stick to `export default` or named exports.