### PR TITLE
[CAN-3237] Fixes how body & header keys look like on json logs

### DIFF
--- a/lib/formatters/ExtendedFormatter.js
+++ b/lib/formatters/ExtendedFormatter.js
@@ -1,9 +1,16 @@
 const BaseFormatter = require('./BaseFormatter');
 const serialize = require('../serializers/toKeyValue');
 const chalk = require('chalk');
+const flat = require('flat');
 
 class ExtendedFormatter extends BaseFormatter {
   formatObject(obj) {
+    if (obj.metaHeaders) {
+      obj.metaHeaders = flat(obj.metaHeaders, { safe: true });
+    }
+    if (obj.metaBody) {
+      obj.metaBody = flat(obj.metaBody, { safe: true });
+    }
     if (this.color) {
       return this.getPrefix(obj) + ' | ' + chalk.grey(serialize(obj));
     } else {

--- a/lib/formatters/JsonFormatter.js
+++ b/lib/formatters/JsonFormatter.js
@@ -1,3 +1,4 @@
+const { merge } = require('lodash');
 const BaseFormatter = require('./BaseFormatter');
 
 class JsonFormatter extends BaseFormatter {
@@ -60,11 +61,10 @@ class JsonFormatter extends BaseFormatter {
         id: obj.requestId
       }
     };
-
+    const meta = merge(metaBody, metaHeaders);
     return {
       ...defaultObject,
-      ...metaBody,
-      ...metaHeaders,
+      ...meta,
       ...remainingProperties
     };
   }

--- a/lib/formatters/SimpleFormatter.js
+++ b/lib/formatters/SimpleFormatter.js
@@ -1,5 +1,6 @@
 const BaseFormatter = require('./BaseFormatter');
 const chalk = require('chalk');
+const flat = require('flat');
 const serialize = require('../serializers/toKeyValue');
 
 class SimpleFormatter extends BaseFormatter {
@@ -19,6 +20,12 @@ class SimpleFormatter extends BaseFormatter {
       requestId,
       ...rest
     } = obj;
+    if (rest.metaHeaders) {
+      rest.metaHeaders = flat(rest.metaHeaders, { safe: true });
+    }
+    if (rest.metaBody) {
+      rest.metaBody = flat(rest.metaBody, { safe: true });
+    }
     if (options && options.traceHeaderName) {
       rest.metaHeaders && delete rest.metaHeaders['headers.' + options.traceHeaderName.toLowerCase()];
     }

--- a/lib/loggable.js
+++ b/lib/loggable.js
@@ -1,5 +1,4 @@
 const EventEmitter = require('events');
-const flat = require('flat');
 
 const EVENT = {
   INBOUND_REQUEST: 'inbound_request',

--- a/lib/transformers/transformers.js
+++ b/lib/transformers/transformers.js
@@ -1,5 +1,4 @@
 const logTags = require('../logTags');
-const flat = require('flat');
 const pick = require('lodash/pick');
 const pickBy = require('lodash/pickBy');
 const url = require('url');
@@ -91,7 +90,7 @@ const mapOutReq = (requestOptions, reqId, opts = {}) => {
         picked = pick(jsonObject, opts.bodyKeys);
       }
       if (Object.keys(picked).length) {
-        metaBody = flat({ body: picked }, { safe: true });
+        metaBody = { body: picked };
       }
     } catch (e) {}
   }
@@ -160,7 +159,11 @@ function extractRequestMeta(ctx, bodyKeys, bodyKeysRegex, headersRegex, prefix =
       picked = pick(ctx.request.body, bodyKeys);
     }
     if (Object.keys(picked).length) {
-      metaBody = flat({ [`${prefix + (prefix && '.')}body`]: picked }, { safe: true });
+      if (prefix) {
+        metaBody = { [prefix]: { body: picked } };
+      } else {
+        metaBody = { body: picked };
+      }
     }
   }
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,5 +1,3 @@
-const flat = require('flat');
-
 function safeExec(fn, logger) {
   try {
     return fn();
@@ -22,7 +20,11 @@ function extractHeaders(headersRegex, headers, prefix = '') {
   });
 
   if (Object.keys(metaHeaders).length) {
-    metaHeaders = flat({ [`${prefix + (prefix && '.')}headers`]: metaHeaders });
+    if (prefix) {
+      metaHeaders = { [prefix]: { headers: metaHeaders } };
+    } else {
+      metaHeaders = { headers: metaHeaders };
+    }
   }
 
   return metaHeaders;

--- a/test/lib/adapters/default/onInboundRequestTest.js
+++ b/test/lib/adapters/default/onInboundRequestTest.js
@@ -106,7 +106,7 @@ describe('#defaultAdapter', () => {
         query: null,
         requestId: uuid,
         metaBody: {
-          'body.skills': 'ok'
+          body: { skills: 'ok' }
         },
         userAgent: '',
         log_tag: 'inbound_request'
@@ -277,7 +277,7 @@ describe('#defaultAdapter', () => {
         path: '/test',
         query: null,
         requestId: uuid,
-        metaHeaders: { 'headers.XX-something': true },
+        metaHeaders: { headers: { 'XX-something': true } },
         userAgent: '',
         log_tag: 'inbound_request'
       });

--- a/test/lib/adapters/default/onOutboundResponseTest.js
+++ b/test/lib/adapters/default/onOutboundResponseTest.js
@@ -56,9 +56,9 @@ describe('#defaultAdapter', () => {
         requestId: uuid,
         log_tag: 'inbound_request',
         userAgent: '',
-        metaBody: { 'body.skills': 'node.js' },
+        metaBody: { body: { skills: 'node.js' } },
         metaHeaders: {
-          'headers.Location': '/test/foo'
+          headers: { Location: '/test/foo' }
         }
       });
       opts.logger.info.args[1][0].should.eql({
@@ -72,10 +72,10 @@ describe('#defaultAdapter', () => {
         requestId: uuid,
         headers: {},
         metaBody: {
-          'request.body.skills': 'node.js'
+          request: { body: { skills: 'node.js' } }
         },
         metaHeaders: {
-          'request.headers.Location': '/test/foo'
+          request: { headers: { Location: '/test/foo' } }
         },
         userAgent: '',
         contentLength: 0,
@@ -180,7 +180,7 @@ describe('#defaultAdapter', () => {
         path: '/test',
         query: null,
         requestId: uuid,
-        headers: { 'headers.Location': '/test/foo' },
+        headers: { headers: { Location: '/test/foo' } },
         contentLength: 0,
         userAgent: '',
         log_tag: 'outbound_response'

--- a/test/lib/adapters/default/requestProxyTest.js
+++ b/test/lib/adapters/default/requestProxyTest.js
@@ -254,7 +254,7 @@ describe('#defaultAdapter', () => {
       http.request = new Proxy(http.request, requestProxy);
       http.request(options);
       logger.info.callCount.should.eql(2);
-      logger.info.args[0][0].metaHeaders.should.have.property('headers.test');
+      logger.info.args[0][0].metaHeaders.headers.should.have.property('test');
       logger.info.args[0][0].should.containEql({
         method: 'GET',
         protocol: 'https',

--- a/test/lib/formatters/ExtendedFormatterTest.js
+++ b/test/lib/formatters/ExtendedFormatterTest.js
@@ -15,7 +15,21 @@ describe('Test Extended Formatter', () => {
   it('formatOsbject should return base prefix', () => {
     const obj = { method: 'GET', requestId: 'testRequestId', path: 'test-path', log_tag: 'inbound_request' };
     const payload = this.extendedFormatter.formatObject(obj);
-
     payload.should.containEql('Test Prefix |');
+  });
+
+  it('formatObject should return object with flatten header & body keys', () => {
+    const obj = {
+      method: 'GET',
+      requestId: 'testRequestId',
+      path: 'test-path',
+      log_tag: 'inbound_request',
+      metaBody: { body: { fruit: 'banana', items: ['apple', 'orange'] } },
+      metaHeaders: { headers: { 'x-custom-header': 'test' } }
+    };
+    const payload = this.extendedFormatter.formatObject(obj);
+    payload.should.containEql('body.fruit="banana"');
+    payload.should.containEql('body.items=["apple", "orange"]');
+    payload.should.containEql('headers.x-custom-header="test"');
   });
 });

--- a/test/lib/formatters/JsonFormatterTest.js
+++ b/test/lib/formatters/JsonFormatterTest.js
@@ -39,6 +39,31 @@ describe('Test Json Formatter', () => {
     json.httpRequest.latency.should.equal('0.050000s');
   });
 
+  it('formatObject should return header and body keys as single object', () => {
+    const obj = {
+      method: 'GET',
+      requestId: 'testRequestId',
+      path: 'test-path',
+      log_tag: 'inbound_request',
+      duration: 50,
+      metaBody: { request: { body: { company: 'workable' } } },
+      metaHeaders: { request: { headers: { 'x-request-id': '123456' } } }
+    };
+    const payload = this.jsonFormatter.formatObject(obj);
+
+    const json = JSON.parse(payload);
+
+    json.severity.should.equal('info');
+    json['logging.googleapis.com/operation'].id.should.equal(obj.requestId);
+    json.requestId.should.equal(obj.requestId);
+    json.httpRequest.requestUrl.should.equal(obj.path);
+    json.httpRequest.latency.should.equal('0.050000s');
+    json.request.should.eql({
+      body: { company: 'workable' },
+      headers: { 'x-request-id': '123456' }
+    });
+  });
+
   it('formatObject should return 0 duration if not defined', () => {
     const obj = {
       method: 'GET',

--- a/test/lib/formatters/SimpleFormatterTest.js
+++ b/test/lib/formatters/SimpleFormatterTest.js
@@ -18,4 +18,19 @@ describe('Test Simple Formatter', () => {
 
     payload.should.equal('Test Prefix');
   });
+
+  it('formatObject should return object with flatten header & body keys', () => {
+    const obj = {
+      method: 'GET',
+      requestId: 'testRequestId',
+      path: 'test-path',
+      log_tag: 'inbound_request',
+      metaBody: { body: { fruit: 'banana', items: ['apple', 'orange'] } },
+      metaHeaders: { headers: { 'x-custom-header': 'test' } }
+    };
+    const payload = this.simpleFormatter.formatObject(obj);
+    payload.should.containEql('body.fruit="banana"');
+    payload.should.containEql('body.items=["apple", "orange"]');
+    payload.should.containEql('headers.x-custom-header="test"');
+  });
 });

--- a/test/lib/transformers/transformersTest.js
+++ b/test/lib/transformers/transformersTest.js
@@ -54,7 +54,7 @@ describe('mapOutReq', () => {
       requestId: undefined,
       metaBody: {},
       metaHeaders: {
-        'headers.x-transaction-id': 'transaction-id'
+        headers: { 'x-transaction-id': 'transaction-id' }
       },
       contentLength: 0,
       log_tag: 'outbound_request'
@@ -94,7 +94,7 @@ describe('mapOutReq', () => {
       log_tag: 'outbound_request',
       metaHeaders: {},
       metaBody: {
-        'body.foo': 'bar'
+        body: { foo: 'bar' }
       }
     });
   });
@@ -132,8 +132,10 @@ describe('mapOutReq', () => {
       log_tag: 'outbound_request',
       metaHeaders: {},
       metaBody: {
-        'body.banana1': 'apple1',
-        'body.banana2': 'apple2'
+        body: {
+          banana1: 'apple1',
+          banana2: 'apple2'
+        }
       }
     });
   });


### PR DESCRIPTION
## Summary
Fixes how body & header keys look like on json logs

### SimlpleFormatter
Before
```
[2020-09-23T16:48:53.676Z] [c7db6700-fd1b-4982-8619-08bc0a7a2ded] --> POST /test 200 8ms 20b | request.headers.x-request-id="c7db6700-fd1b-4982-8619-08bc0a7a2ded", request.body.candidate.firstname="kyriakos", request.body.candidate.lastname="lesgidis"
```
After
```
[2020-09-23T17:00:41.429Z] [58f56ada-63ec-462e-ab39-169fa33f24e4] --> POST /test 200 5ms 20b | request.headers.x-request-id="58f56ada-63ec-462e-ab39-169fa33f24e4", request.body.candidate.firstname="kyriakos", request.body.candidate.lastname="lesgidis"
```

### ExtendedFormatter
Before
```
[2020-09-23T16:49:59.084Z] [b30b86f3-6b08-47da-ae68-d9a0df142dd7] --> POST /test 200 6ms 20b | status=200, duration=6, requestId="b30b86f3-6b08-47da-ae68-d9a0df142dd7", method="POST", protocol="http", path="/test", request.headers.x-request-id="b30b86f3-6b08-47da-ae68-d9a0df142dd7", request.body.candidate.firstname="kyriakos", request.body.candidate.lastname="lesgidis", log_tag="outbound_response", contentLength=20, userAgent="PostmanRuntime/7.26.5"
```
After
```
[2020-09-23T16:57:08.250Z] [0a4b907d-4d1f-4941-9aa0-4ddc28005520] --> POST /test 200 12ms 20b | status=200, duration=12, requestId="0a4b907d-4d1f-4941-9aa0-4ddc28005520", method="POST", protocol="http", path="/test", request.headers.x-request-id="0a4b907d-4d1f-4941-9aa0-4ddc28005520", request.body.candidate.firstname="kyriakos", request.body.candidate.lastname="lesgidis", log_tag="outbound_response", contentLength=20, userAgent="PostmanRuntime/7.26.5"
```

### JsonFormatter
Before
```
{"severity":"info","timestamp":"2020-09-23T17:03:50.180Z","httpRequest":{"requestMethod":"POST","requestUrl":"/test","status":200,"protocol":"http","latency":"0.006000s","responseSize":20,"userAgent":"PostmanRuntime/7.26.5"},"logging.googleapis.com/operation":{"id":"ed5fa096-74f8-46fa-ace5-fc8a519c3b46"},"request.body.candidate.firstname":"kyriakos","request.body.candidate.lastname":"lesgidis","request":{"headers":{"x-request-id":"ed5fa096-74f8-46fa-ace5-fc8a519c3b46"}},"headers":{},"requestId":"ed5fa096-74f8-46fa-ace5-fc8a519c3b46","query":null,"log_tag":"outbound_response"}
```
After
```
{"severity":"info","timestamp":"2020-09-23T20:33:00.217Z","httpRequest":{"requestMethod":"POST","requestUrl":"/test","status":200,"protocol":"http","latency":"0.007000s","responseSize":20,"userAgent":"PostmanRuntime/7.26.5"},"logging.googleapis.com/operation":{"id":"59c08aab-0e10-4b21-bdad-17fa10dd4b3c"},"request":{"body":{"candidate":{"firstname":"kyriakos","lastname":"lesgidis"}},"headers":{"x-request-id":"59c08aab-0e10-4b21-bdad-17fa10dd4b3c"}},"headers":{},"requestId":"59c08aab-0e10-4b21-bdad-17fa10dd4b3c","query":null,"log_tag":"outbound_response"}
```

The above requests are after testing `riviere` manually
