### PR TITLE
[PROD-1852] [ENG-80] Add option for disabling outbound request logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,9 +32,10 @@ Use `riviere` if you want an easy way to log all the HTTP traffic for your serve
     11. [headersRegex](#options_headers_regex)
     12. [health](#options_health)
     13. [outbound.enabled](#options_outbound_enabled)
-    14. [outbound.maxBodyValueChars](#options_outbound_max_body_value_chars)
-    15. [outbound.blacklistedPathRegex](#options_outbound_blacklisted_path_regex)
-    16. [traceHeaderName](#options_trace_header_name)
+    14. [outbound.request.enabled](#options_outbound_request_enabled)
+    15. [outbound.maxBodyValueChars](#options_outbound_max_body_value_chars)
+    16. [outbound.blacklistedPathRegex](#options_outbound_blacklisted_path_regex)
+    17. [traceHeaderName](#options_trace_header_name)
 8. [License](#License)
 
 ---
@@ -163,6 +164,9 @@ const configuration = {
     },
     outbound: {
         enabled: true,
+        request: {
+            enabled: true
+        },
         maxBodyValueChars: undefined
     },
     bodyKeys: [],
@@ -433,6 +437,11 @@ Enable outbound HTTP traffic logs. Defaults to `true`.
     }
 }
 ```
+
+<a name="options_outbound_request_enabled"></a>
+**outbound.request.enabled**
+
+Enable outbound_request HTTP traffic logging. Defaults to `true`.
 
 <a name="options_outbound_max_body_value_chars"></a>
 **outbound.maxBodyValueChars**

--- a/lib/adapters/default.js
+++ b/lib/adapters/default.js
@@ -34,7 +34,9 @@ function requestProxy(options = {}) {
           // do not log custom requests (for example requests started by the newrelic agent)
           return target.apply(thisArg, argumentsList);
         }
-        logger[level](reqObj, options);
+        if (opts.request && opts.request.enabled) {
+          logger[level](reqObj, options);
+        }
       } catch (err) {
         logger.error(err);
         return target.apply(thisArg, argumentsList);

--- a/lib/options.js
+++ b/lib/options.js
@@ -36,6 +36,9 @@ module.exports = (options = {}) => {
     },
     outbound: {
       enabled: true,
+      request: {
+        enabled: true
+      },
       level: 'info',
       maxQueryChars: undefined,
       maxPathChars: undefined,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@workablehr/riviere",
-  "version": "1.12.1",
+  "version": "1.12.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@workablehr/riviere",
-  "version": "1.12.1",
+  "version": "1.12.2",
   "description": "log inbound/outbound HTTP traffic",
   "types": "./types/riviere.d.ts",
   "main": "index.js",


### PR DESCRIPTION
## Before
Riviere would log `outbound_request` and `inbound_response`

## After
Riviere would log `outbound_request` and `inbound_response` but you would also have an option to enable/disable the logging of `outbound_request` by passing it on the configuration