### PR TITLE
Add Prefix to Inbound Header Logs

### DIFF
--- a/lib/transformers/transformers.js
+++ b/lib/transformers/transformers.js
@@ -104,8 +104,7 @@ const mapInRes = (res, req, startedAt, reqId, opts) => {
     contentLength,
     userAgent,
     log_tag: logTags.CATEGORY.INBOUND_RESPONSE.TAG,
-    metaHeaders: { request: req.metaHeaders },
-    headers
+    metaHeaders: { request: req.metaHeaders, ...headers }
   };
 };
 

--- a/test/lib/adapters/default/requestProxyTest.js
+++ b/test/lib/adapters/default/requestProxyTest.js
@@ -30,7 +30,8 @@ describe('#defaultAdapter', () => {
         opts: {
           request: {
             enabled: true
-          }
+          },
+          headersRegex: new RegExp('^X-.*', 'i')
         }
       });
       const options = {
@@ -59,7 +60,7 @@ describe('#defaultAdapter', () => {
       const httpRequest = () => {
         return {
           on: (on, cb) => {
-            const res = {};
+            const res = { headers: { 'x-foo': 'foo' } };
             cb(res);
             logger.info.callCount.should.equal(2);
             logger.info.args[0][0].should.eql({
@@ -89,8 +90,7 @@ describe('#defaultAdapter', () => {
               contentLength: 0,
               userAgent: '',
               log_tag: 'inbound_response',
-              headers: {},
-              metaHeaders: { request: {} }
+              metaHeaders: { request: {}, headers: { 'x-foo': 'foo' } }
             });
           }
         };
@@ -276,7 +276,6 @@ describe('#defaultAdapter', () => {
         contentLength: 0,
         userAgent: '',
         log_tag: 'inbound_response',
-        headers: {},
         metaHeaders: { request: {} }
       });
     });
@@ -417,7 +416,6 @@ describe('#defaultAdapter', () => {
         contentLength: 0,
         userAgent: '',
         log_tag: 'inbound_response',
-        headers: {},
         metaHeaders: { request: {} }
       });
     });
@@ -491,7 +489,6 @@ describe('#defaultAdapter', () => {
         contentLength: 0,
         userAgent: '',
         log_tag: 'inbound_response',
-        headers: {},
         metaHeaders: {
           request: {}
         }
@@ -718,7 +715,6 @@ describe('#defaultAdapter', () => {
               contentLength: 0,
               userAgent: '',
               log_tag: 'inbound_response',
-              headers: {},
               metaHeaders: {
                 request: {}
               }


### PR DESCRIPTION


## Description
This pull request introduces a prefix to inbound header logs. 
The change is made in the `transformers.js` file and is reflected in the `requestProxyTest.js` tests. 
This enhancement will aid in better log management by differentiating inbound headers.

## Changes
- Updated the `mapInRes` function in `transformers.js` to include headers in `metaHeaders`
- Adjusted tests in `requestProxyTest.js` to reflect the changes in `transformers.js`

## Jira tickets
- None provided