### PR TITLE
[PROD-36670] Expose new headerValueCallback option that will called on every visible header

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,12 +31,13 @@ Use `riviere` if you want an easy way to log all the HTTP traffic for your serve
     10. [context](#options_context)
     11. [errors.callback](#options_errors_callback)
     12. [headersRegex](#options_headers_regex)
-    13. [health](#options_health)
-    14. [outbound.enabled](#options_outbound_enabled)
-    15. [outbound.request.enabled](#options_outbound_request_enabled)
-    16. [outbound.maxBodyValueChars](#options_outbound_max_body_value_chars)
-    17. [outbound.blacklistedPathRegex](#options_outbound_blacklisted_path_regex)
-    18. [traceHeaderName](#options_trace_header_name)
+    13. [headerValueCallback](#options_header_value_callback)
+    14. [health](#options_health)
+    15. [outbound.enabled](#options_outbound_enabled)
+    16. [outbound.request.enabled](#options_outbound_request_enabled)
+    17. [outbound.maxBodyValueChars](#options_outbound_max_body_value_chars)
+    18. [outbound.blacklistedPathRegex](#options_outbound_blacklisted_path_regex)
+    19. [traceHeaderName](#options_trace_header_name)
 8. [License](#License)
 
 ---
@@ -424,6 +425,27 @@ All the inbound request's headers starting with "X-" will be logged by default.
 ```js
 {
     headersRegex: new RegExp('X-.+', 'i')
+}
+```
+
+<a name="options_header_value_callback"></a>
+**headerValueCallback**
+
+This option can be used to let you modify or change part or the whole value of a header. 
+This function will be applied to all headers that are passed based on the `headersRegex`. 
+This function takes two argument, the `key` (i.e. the header name) and the `value` (i.e. the header value) and returns the new value of the header.
+This function is very useful in cases where is mandatory to hide or remove sensitive data that is part of the header value.
+Defaults to undefined. In case of undefined then the header value will remain as is.
+
+*Example*:
+In this example we hide some sensitive `id_token` value.
+
+```js
+{
+    headerValueCallback: (key, value) {
+        const regex = /id_token=[\w-]+\.[\w-]+\.[\w-]+/i;
+        return value.replace(regex, 'id_token=***');
+    };
 }
 ```
 

--- a/examples/withHeaderValueCallback.js
+++ b/examples/withHeaderValueCallback.js
@@ -1,0 +1,25 @@
+const Koa = require('koa');
+const riviere = require('../index');
+const request = require('request-promise');
+
+const app = new Koa();
+
+app.use(
+  riviere({
+    outbound: {
+      enabled: true
+    },
+    styles: ['extended'],
+    headerValueCallback: (key, value) => {
+      const regex = /id_token=[\w-]+\.[\w-]+\.[\w-]+/i;
+      return value.replace(regex, 'id_token=***');
+    }
+  })
+);
+
+app.use(async function(ctx) {
+  ctx.body = 'Hello World';
+  ctx.set('x-something', 'id_token=some.token.to-hide');
+});
+
+app.listen(3000);

--- a/index.js
+++ b/index.js
@@ -9,7 +9,7 @@ const httpsProxy = require('./lib/proxies/https').proxy;
 const { EVENT } = Loggable;
 
 function buildRiviere(options = {}) {
-  const { errors = {}, logger, inbound, outbound, traceHeaderName, headersRegex } = defaultsDeep(
+  const { errors = {}, logger, inbound, outbound, traceHeaderName, headersRegex, headerValueCallback } = defaultsDeep(
     options,
     defaultOptions(options)
   );
@@ -26,6 +26,7 @@ function buildRiviere(options = {}) {
         bodyKeys: options.bodyKeys,
         bodyKeysRegex: options.bodyKeysRegex,
         bodyKeysCallback: options.bodyKeysCallback,
+        headerValueCallback,
         ...outbound
       }
     });

--- a/lib/adapters/default.js
+++ b/lib/adapters/default.js
@@ -93,6 +93,7 @@ function onInboundRequest({ ctx }) {
     bodyKeysRegex,
     bodyKeysCallback,
     headersRegex,
+    headerValueCallback,
     inbound: { maxBodyValueChars }
   } = this;
   const transformedReq = mapInReq({
@@ -102,6 +103,7 @@ function onInboundRequest({ ctx }) {
     bodyKeysRegex,
     bodyKeysCallback,
     headersRegex,
+    headerValueCallback,
     maxBodyValueChars
   });
 
@@ -119,6 +121,7 @@ function onOutboundResponse({ ctx }) {
     bodyKeysRegex,
     bodyKeysCallback,
     headersRegex,
+    headerValueCallback,
     outbound: { maxBodyValueChars }
   } = this;
   const transformedRes = mapOutRes({
@@ -128,6 +131,7 @@ function onOutboundResponse({ ctx }) {
     bodyKeysRegex,
     bodyKeysCallback,
     headersRegex,
+    headerValueCallback,
     maxBodyValueChars
   });
   this.logger[this.inbound.level](transformedRes, this);

--- a/lib/loggable.js
+++ b/lib/loggable.js
@@ -16,6 +16,7 @@ class Loggable extends EventEmitter {
       bodyKeysCallback,
       context,
       headersRegex,
+      headerValueCallback,
       health,
       inbound,
       outbound,
@@ -32,6 +33,7 @@ class Loggable extends EventEmitter {
     this.bodyKeysRegex = bodyKeysRegex;
     this.bodyKeysCallback = bodyKeysCallback;
     this.headersRegex = headersRegex;
+    this.headerValueCallback = headerValueCallback;
     this.health = health;
     this.inbound = inbound;
     this.outbound = outbound;

--- a/lib/options.js
+++ b/lib/options.js
@@ -55,6 +55,7 @@ module.exports = (options = {}) => {
     bodyKeysRegex: undefined,
     bodyKeysCallback: undefined,
     headersRegex: new RegExp('^X-.*', 'i'),
+    headerValueCallback: undefined,
     traceHeaderName: 'X-Riviere-Id',
     forceIds: true
   };

--- a/lib/transformers/transformers.js
+++ b/lib/transformers/transformers.js
@@ -37,13 +37,30 @@ const mapError = ({ ctx, err }) => {
 /**
  * Server HTTP in and out responses
  */
-const mapInReq = ({ ctx, health, bodyKeys, bodyKeysRegex, bodyKeysCallback, headersRegex, maxBodyValueChars }) => {
+const mapInReq = ({
+  ctx,
+  health,
+  bodyKeys,
+  bodyKeysRegex,
+  bodyKeysCallback,
+  headersRegex,
+  headerValueCallback,
+  maxBodyValueChars
+}) => {
   if (isHealth(ctx, health)) {
     return Object.assign({}, ctx.logCtx, {
       log_tag: logTags.CATEGORY.INBOUND_REQUEST_HEALTH.TAG
     });
   }
-  const meta = extractRequestMeta(ctx, bodyKeys, bodyKeysRegex, bodyKeysCallback, maxBodyValueChars, headersRegex);
+  const meta = extractRequestMeta(
+    ctx,
+    bodyKeys,
+    bodyKeysRegex,
+    bodyKeysCallback,
+    maxBodyValueChars,
+    headersRegex,
+    headerValueCallback
+  );
 
   let userAgent = getUserAgent(ctx.headers);
 
@@ -53,11 +70,20 @@ const mapInReq = ({ ctx, health, bodyKeys, bodyKeysRegex, bodyKeysCallback, head
   });
 };
 
-const mapOutRes = ({ ctx, health, bodyKeys, bodyKeysRegex, bodyKeysCallback, headersRegex, maxBodyValueChars }) => {
+const mapOutRes = ({
+  ctx,
+  health,
+  bodyKeys,
+  bodyKeysRegex,
+  bodyKeysCallback,
+  headersRegex,
+  headerValueCallback,
+  maxBodyValueChars
+}) => {
   const status = ctx.status;
   const duration = new Date().getTime() - ctx.state.riviereStartedAt;
 
-  const headers = extractHeaders(headersRegex, ctx.response.headers);
+  const headers = extractHeaders(headersRegex, headerValueCallback, ctx.response.headers);
 
   if (isHealth(ctx, health)) {
     return Object.assign({}, ctx.logCtx, {
@@ -74,6 +100,7 @@ const mapOutRes = ({ ctx, health, bodyKeys, bodyKeysRegex, bodyKeysCallback, hea
     bodyKeysCallback,
     maxBodyValueChars,
     headersRegex,
+    headerValueCallback,
     'request'
   );
 
@@ -97,7 +124,7 @@ const mapInRes = (res, req, startedAt, reqId, opts) => {
   let contentLength = getContentLength(res.headers);
   let userAgent = getUserAgent(res.headers);
 
-  const headers = extractHeaders(opts.headersRegex, res.headers);
+  const headers = extractHeaders(opts.headersRegex, opts.headerValueCallback, res.headers);
   return {
     ...pick(req, ['method', 'protocol', 'host', 'path', 'query', 'href']),
     status,
@@ -115,6 +142,7 @@ const mapOutReq = (requestOptions, reqId, opts = {}) => {
   const port = requestOptions.port;
   const requestId = reqId;
   const headersRegex = opts.headersRegex;
+  const headerValueCallback = opts.headerValueCallback;
 
   const { protocol, host, path, query, href } = getUrlParameters(requestOptions);
 
@@ -124,7 +152,7 @@ const mapOutReq = (requestOptions, reqId, opts = {}) => {
   const slicedPath = truncateText(path, maxPathChars);
   const slicedHref = truncateText(href, maxHrefChars);
 
-  const metaHeaders = extractHeaders(headersRegex, requestOptions.headers);
+  const metaHeaders = extractHeaders(headersRegex, headerValueCallback, requestOptions.headers);
 
   let metaBody = {};
 
@@ -184,12 +212,13 @@ function extractRequestMeta(
   bodyKeysCallback,
   maxBodyValueChars,
   headersRegex,
+  headerValueCallback,
   prefix = ''
 ) {
   const method = ctx.request.method;
 
   // pick headers
-  const metaHeaders = extractHeaders(headersRegex, ctx.request.headers, prefix);
+  const metaHeaders = extractHeaders(headersRegex, headerValueCallback, ctx.request.headers, prefix);
 
   // pick body
   let metaBody;

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -6,16 +6,19 @@ function safeExec(fn, logger) {
   }
 }
 
-function extractHeaders(headersRegex, headers, prefix = '') {
+function extractHeaders(headersRegex, headerValueCallback, headers, prefix = '') {
   let metaHeaders = {};
 
   if (!headersRegex) {
     return metaHeaders;
   }
 
+  const headerValue =
+    headerValueCallback && typeof headerValueCallback === 'function' ? headerValueCallback : (key, value) => value;
+
   Object.keys(headers).forEach(header => {
     if (new RegExp(headersRegex).test(header)) {
-      metaHeaders[header] = headers[header];
+      metaHeaders[header] = headerValue(header, headers[header]);
     }
   });
 

--- a/types/riviere.d.ts
+++ b/types/riviere.d.ts
@@ -30,6 +30,7 @@ export function riviere(options?: {
   bodyKeysRegex?: RegExp,
   bodyKeysCallback?: (body: any, ctx?: any) => any,
   headersRegex?: RegExp,
+  headerValueCallback?: (key: string, value: any) => any,
   traceHeaderName?: string,
   forceIds?: boolean
 }): any;


### PR DESCRIPTION
## Summary

This PR exposes a new callback function, the `headerValueCallback`. This function will be called on every visible header. And will give the ability to mutate the value of the header that will be logged.

This is useful in cases where the header value contains sensitive data that needed to be hide.

This PR is created as part of fixing the following issue: https://workable.atlassian.net/browse/PROD-36670
where the JWT token is part of the `location` header and although that the `location` header is needed to be logged it is also needed to not include `id_token` as part of it, because of a security issue.