### PR TITLE
PROD-54189 Fix regex configuration via environment variables

### DIFF
--- a/lib/adapters/default.js
+++ b/lib/adapters/default.js
@@ -29,7 +29,10 @@ function requestProxy(options = {}) {
         reqId = requestOptions.headers[traceHeaderName];
 
         reqObj = mapOutReq(requestOptions, reqId, opts);
-        const blacklistedPathRegex = opts.blacklistedPathRegex;
+        const blacklistedPathRegex =
+          typeof opts.blacklistedPathRegex === 'string'
+            ? new RegExp(opts.blacklistedPathRegex, 'gi')
+            : opts.blacklistedPathRegex;
         if (!reqObj.protocol || (blacklistedPathRegex && blacklistedPathRegex.test(reqObj.path))) {
           // do not log custom requests (for example requests started by the newrelic agent)
           return target.apply(thisArg, argumentsList);

--- a/lib/transformers/transformers.js
+++ b/lib/transformers/transformers.js
@@ -179,7 +179,7 @@ const mapOutReq = (requestOptions, reqId, opts = {}) => {
       if (opts.bodyKeysCallback && typeof opts.bodyKeysCallback === 'function') {
         picked = opts.bodyKeysCallback(picked);
       } else if (opts.bodyKeysRegex) {
-        const REGEX = opts.bodyKeysRegex;
+        const REGEX = typeof opts.bodyKeysRegex === 'string' ? new RegExp(opts.bodyKeysRegex, 'i') : opts.bodyKeysRegex;
         picked = pickBy(picked, (_, key) => REGEX.test(key));
       } else {
         picked = pick(picked, opts.bodyKeys);

--- a/test/lib/transformers/transformersTest.js
+++ b/test/lib/transformers/transformersTest.js
@@ -274,4 +274,45 @@ describe('mapOutReq', () => {
       log_tag: 'outbound_request'
     });
   });
+
+  it('should convert a string bodyKeysRegex to RegExp', () => {
+    const inMsg = {
+      method: 'POST',
+      body: '{ "bananas": "bar", "banana1": "apple1", "banana2": "apple2" }',
+      headers: {
+        'Content-type': 'application/json; charset=UTF-8'
+      },
+      uri: {
+        protocol: 'http:',
+        hostname: 'hostname',
+        pathname: 'path',
+        query: 'query'
+      }
+    };
+
+    const options = {
+      bodyKeysRegex: '^banana\\d+'
+    };
+
+    const result = mapOutReq(inMsg, undefined, options);
+    result.should.eql({
+      method: 'POST',
+      protocol: 'http',
+      host: 'hostname',
+      port: undefined,
+      path: 'path',
+      query: 'query',
+      href: 'http://hostname/path',
+      requestId: undefined,
+      contentLength: 0,
+      log_tag: 'outbound_request',
+      metaHeaders: {},
+      metaBody: {
+        body: {
+          banana1: 'apple1',
+          banana2: 'apple2'
+        }
+      }
+    });
+  });
 });


### PR DESCRIPTION
When an expected Regex would be passed as a string (which happens when setting regexes via environment variables) then riviere would throw in specific points and not log requests.